### PR TITLE
feat(trellis): upgrade to PIXI.js v8.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,12 +61,11 @@
   "author": "James Conkling <james.lane.conkling@gmail.com> jameslaneconkling.github.io",
   "license": "ISC",
   "dependencies": {
-    "@pixi/events": "^7.3.2",
     "d3-force": "^3.0.0",
     "d3-hierarchy": "^3.1.2",
     "d3-interpolate": "^3.0.1",
     "fontfaceobserver": "^2.3.0",
-    "pixi.js": "^7.3.2",
+    "pixi.js": "^8.6.6",
     "stats.js": "^0.17.0"
   },
   "devDependencies": {
@@ -75,12 +74,14 @@
     "@parcel/transformer-typescript-types": "^2.10.1",
     "@turf/clusters-kmeans": "^6.5.0",
     "@types/css-font-loading-module": "^0.0.10",
+    "@types/d3-color": "^3.1.3",
     "@types/d3-force": "^3.0.7",
     "@types/d3-hierarchy": "^3.1.5",
     "@types/d3-interpolate": "^3.0.3",
     "@types/d3-scale": "^4.0.6",
     "@types/d3-scale-chromatic": "^3.0.1",
     "@types/fontfaceobserver": "^2.1.3",
+    "@types/node": "^22.10.6",
     "@types/react": "^18.2.33",
     "@types/react-dom": "^18.2.14",
     "@types/stats.js": "^0.17.2",

--- a/src/renderers/webgl/extensions.ts
+++ b/src/renderers/webgl/extensions.ts
@@ -1,0 +1,13 @@
+// Import required PIXI extensions
+import 'pixi.js/events' // For event handling
+import 'pixi.js/text' // For text rendering
+import 'pixi.js/text-bitmap' // For bitmap text
+import 'pixi.js/graphics' // For graphics rendering
+import 'pixi.js/sprite' // For sprite rendering
+import 'pixi.js/rendering' // For WebGL/WebGPU rendering
+
+// Export a function to ensure extensions are loaded
+export function initializePixiExtensions() {
+  // Extensions are loaded when imported
+  // This function exists to ensure the imports are not tree-shaken
+}

--- a/src/renderers/webgl/textures/ArrowTexture.ts
+++ b/src/renderers/webgl/textures/ArrowTexture.ts
@@ -1,4 +1,4 @@
-import { RenderTexture, Graphics, Matrix, MSAA_QUALITY, Renderer as PixiRenderer } from 'pixi.js'
+import { RenderTexture, Graphics, Renderer as PixiRenderer } from 'pixi.js'
 import { MIN_TEXTURE_ZOOM } from '../../../utils/constants'
 import { Texture } from '../../../types'
 import { Renderer } from '..'
@@ -15,18 +15,14 @@ export default class ArrowTexture implements Texture {
     this.texture = RenderTexture.create({
       width: graphic.width,
       height: graphic.height,
-      multisample: MSAA_QUALITY.HIGH,
-      resolution: 2
+      resolution: 2,
+      scaleMode: 'linear',
+      alphaMode: 'premultiply-alpha-on-upload'
     })
 
-    renderer.app.renderer.render(graphic, {
-      renderTexture: this.texture,
-      transform: new Matrix(1, 0, 0, 1, 0, graphic.height / 2)
-    })
-
-    if (renderer.app.renderer instanceof PixiRenderer) {
-      renderer.app.renderer.framebuffer.blit()
-    }
+    const pixiRenderer = renderer.app.renderer as PixiRenderer
+    pixiRenderer.render(graphic, { renderTexture: this.texture })
+    this.texture.baseTexture.update()
 
     graphic.destroy(true)
   }

--- a/src/renderers/webgl/textures/CircleTexture.ts
+++ b/src/renderers/webgl/textures/CircleTexture.ts
@@ -1,4 +1,4 @@
-import { RenderTexture, Graphics, Matrix, MSAA_QUALITY, Renderer as PixiRenderer } from 'pixi.js'
+import { RenderTexture, Graphics, Renderer as PixiRenderer } from 'pixi.js'
 import { MIN_TEXTURE_ZOOM } from '../../../utils/constants'
 import { Texture } from '../../../types'
 import { Renderer } from '..'
@@ -12,18 +12,14 @@ export default class CircleTexture implements Texture {
     this.texture = RenderTexture.create({
       width: graphic.width,
       height: graphic.height,
-      multisample: MSAA_QUALITY.HIGH,
-      resolution: 2
+      resolution: 2,
+      scaleMode: 'linear',
+      alphaMode: 'premultiply-alpha-on-upload'
     })
 
-    renderer.app.renderer.render(graphic, {
-      renderTexture: this.texture,
-      transform: new Matrix(1, 0, 0, 1, graphic.width / 2, graphic.height / 2)
-    })
-
-    if (renderer.app.renderer instanceof PixiRenderer) {
-      renderer.app.renderer.framebuffer.blit()
-    }
+    const pixiRenderer = renderer.app.renderer as PixiRenderer
+    pixiRenderer.render(graphic, { renderTexture: this.texture })
+    this.texture.baseTexture.update()
 
     graphic.destroy(true)
   }

--- a/src/renderers/webgl/textures/TextIconTexture.ts
+++ b/src/renderers/webgl/textures/TextIconTexture.ts
@@ -1,4 +1,4 @@
-import { RenderTexture, Text as PixiText, MSAA_QUALITY, Matrix, Renderer as PixiRenderer } from 'pixi.js'
+import { RenderTexture, Text as PixiText, Renderer as PixiRenderer } from 'pixi.js'
 import { DEFAULT_RESOLUTION, DEFAULT_TEXT_STYLE, MIN_TEXTURE_ZOOM } from '../../../utils/constants'
 import { TextIcon, Texture } from '../../../types'
 import { Renderer } from '..'
@@ -49,20 +49,19 @@ export default class TextIconTexture implements Texture {
 
     const object = new PixiText(icon.content, style.getTextStyle())
 
-    object.updateText(true)
-
+    // Update to use new RenderTexture options format
     const renderTexture = RenderTexture.create({
       width: object.width,
       height: object.height,
-      multisample: MSAA_QUALITY.HIGH,
-      resolution: this.resolution
+      resolution: this.resolution,
+      scaleMode: 'linear',
+      alphaMode: 'premultiply-alpha-on-upload'
     })
 
-    this.renderer.app.renderer.render(object, { renderTexture, transform: new Matrix() })
-
-    if (this.renderer.app.renderer instanceof PixiRenderer) {
-      this.renderer.app.renderer.framebuffer.blit()
-    }
+    // Render with explicit update handling
+    const renderer = this.renderer.app.renderer as PixiRenderer
+    renderer.render(object, { renderTexture })
+    renderTexture.baseTexture.update()
 
     object.destroy(true)
 


### PR DESCRIPTION
Updates:
- Update package.json dependencies to PIXI.js v8.6.6 
- Add explicit PIXI extension imports in new extensions.ts 
- Update texture rendering to use new RenderTexture API 
- Fix ticker callback types to use Ticker.deltaTime 
- Update Application options for v8 compatibility
-  Remove pixi.js-legacy dependency

Breaking Changes: 
- Events system now included in main package 
- Manual texture updates required 
- New alpha mode handling